### PR TITLE
Холин Кирилл. Лабораторная работа 2: LLVM IR. Вариант 4.

### DIFF
--- a/llvm/compiler-course/llvm-ir/Kholin_K_DivOpt/CMakeLists.txt
+++ b/llvm/compiler-course/llvm-ir/Kholin_K_DivOpt/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(Title "DivOptPass")
+set(Student "KholinKirill")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_LLVM_IR")
+
+if (NOT WIN32 AND NOT CYGWIN)
+    file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+    add_llvm_pass_plugin(${TARGET_NAME} ${SOURCES}
+        DEPENDS
+        intrinsics_gen
+        BUILDTREE_ONLY
+    )
+    set(LLVM_TEST_DEPENDS ${TARGET_NAME} ${LLVM_TEST_DEPENDS} PARENT_SCOPE)
+endif()

--- a/llvm/compiler-course/llvm-ir/Kholin_K_DivOpt/Kholin_K_DivOpt_pass.cpp
+++ b/llvm/compiler-course/llvm-ir/Kholin_K_DivOpt/Kholin_K_DivOpt_pass.cpp
@@ -1,0 +1,97 @@
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/InstrTypes.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Support/raw_ostream.h"
+#include <vector>
+
+using namespace llvm;
+
+namespace {
+
+void visitor(Function &F) {
+    errs() << "Start processing function: " << F.getName() << "\n";
+    for (auto &BB : F) {//function cycle block//
+        errs() << ">Start processing basic block" << "\n";
+        std::vector<BinaryOperator*> DivsToReplace;
+        for (auto &I : BB) {//instruction cycle block
+            if (auto *BinOp = dyn_cast<BinaryOperator>(&I)) {
+                if (BinOp->getOpcode() == Instruction::SDiv || BinOp->getOpcode() == Instruction::UDiv) {
+                    Value *Divisor = BinOp->getOperand(1);//get right operand from result = lhs op rhs
+                    if (ConstantInt *ConstantDivisor = dyn_cast<ConstantInt>(Divisor)) {
+                        if (ConstantDivisor->getValue() == 0) {//value of rhs
+                            errs() << "Division by zero detected in function " << F.getName() << "\n";
+                            continue;
+                        }
+                        if (ConstantDivisor->getValue().isPowerOf2()) {//standart function for check degree 2
+                            errs() << "Processing div instruction: " << *BinOp << "\n";
+                            errs() << "Divisor is a power of 2: " << *ConstantDivisor << "\n";
+                            if (BinOp->getOpcode() == Instruction::SDiv && ConstantDivisor->isNegative()) {// except situation when negative
+                                errs() << "Signed division by negative power of 2 detected in function " << F.getName() << "\n";
+                                continue;
+                            }
+                            DivsToReplace.push_back(BinOp);
+                        }
+                    }
+                }
+            }
+        }
+
+        for (auto *BinOp : DivsToReplace) {//replacing all div instructions to shift
+            uint32_t ShiftAmount = cast<ConstantInt>(BinOp->getOperand(1))->getValue().exactLogBase2();
+            errs() << "Shift amount: " << ShiftAmount << "\n";
+
+            IRBuilder<> Builder(BinOp);//alloca builder
+            errs() << "Initialize Builder for instruction: " << *BinOp << "\n";
+
+            Value *Shift = nullptr;
+
+            if (BinOp->getOpcode() == Instruction::SDiv) {//for signed
+                Shift = Builder.CreateAShr(BinOp->getOperand(0), ShiftAmount);
+            } else {//for unsigned
+                Shift = Builder.CreateLShr(BinOp->getOperand(0), ShiftAmount);
+            }
+            errs() << "Constructed shift instruction: " << *Shift << "\n";
+
+            BinOp->replaceAllUsesWith(Shift);//finally replace
+            errs() << "Division successfully replaced!\n";
+
+            BinOp->eraseFromParent();//delete old op
+            errs() << "Div instruction successfully removed!\n";
+        }
+        errs() << ">End processing basic block" << "\n";
+    }
+    errs() << "End processing function: " << F.getName() << "\n";
+}
+
+struct DivOptPass : PassInfoMixin<DivOptPass> {
+    PreservedAnalyses run(Function &F, FunctionAnalysisManager &) {
+        visitor(F);
+        return PreservedAnalyses::all(); //valid all passes
+    }
+
+    static bool isRequired() { return true; }
+};
+
+} // namespace
+
+llvm::PassPluginLibraryInfo getDivToShiftPluginInfo() {
+    return {LLVM_PLUGIN_API_VERSION, "DivOptPass", LLVM_VERSION_STRING,
+            [](PassBuilder &PB) {
+                PB.registerPipelineParsingCallback(
+                    [](StringRef Name, FunctionPassManager &FPM,
+                       ArrayRef<PassBuilder::PipelineElement>) {
+                        if (Name == "div-opt-pass") {
+                            FPM.addPass(DivOptPass());
+                            return true;
+                        }
+                        return false;
+                    });
+            }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
+llvmGetPassPluginInfo() {
+    return getDivToShiftPluginInfo();
+}

--- a/llvm/test/compiler-course/Kholin_K_DivOpt/Kholin_K_DivOpt_test.cpp
+++ b/llvm/test/compiler-course/Kholin_K_DivOpt/Kholin_K_DivOpt_test.cpp
@@ -1,7 +1,3 @@
-//run ס ןמלמשü‏ opt
-//checks
-//ג .ll פאיכו
-
 #include <iostream>
 
 using namespace std;

--- a/llvm/test/compiler-course/Kholin_K_DivOpt/Kholin_K_DivOpt_test.cpp
+++ b/llvm/test/compiler-course/Kholin_K_DivOpt/Kholin_K_DivOpt_test.cpp
@@ -1,0 +1,60 @@
+//run ס ןמלמשü‏ opt
+//checks
+//ג .ll פאיכו
+
+#include <iostream>
+
+using namespace std;
+
+
+int main() {
+  unsigned int lhs1 = 1024;
+
+  unsigned int result_type_OK1 = lhs1 / 2;
+  unsigned int UB1 = lhs1 / (-2);
+
+  unsigned int lhs2 = 512;
+
+  unsigned int result_type_OK2 = lhs2 / 8u;
+  
+  signed int lhs3 = 256;
+
+  signed int result_type_OK3 = lhs3 / 64;
+  signed int Not_UB1 = lhs3 / (- 64);
+  signed int result_type_OK4 = (-lhs3) / 64;
+  signed int Not_UB2 = (-lhs3) / (-64); 
+
+  signed int lhs4 = 128;
+
+  signed int result_type_OK5 = lhs4 / 32u;
+  signed int UB2 = (-lhs4) / 32u;
+
+  signed int lhs5 = 128;
+
+  signed int result_type_OK7 = lhs5 / 3u;
+  signed int UB3 = (-lhs5) / 3u;
+
+  signed int lhs6 = 126;
+
+  signed int result_type_OK9 = lhs6 / 4;
+  signed int UB4 = (-lhs6) / 4u;
+
+  double lhs7 = 894.93;
+
+  double result_type_OK11 = lhs7 / 4;
+  double result_type_OK12 = lhs7 / (-4);
+
+  int lhs8 = 6;
+
+  int result_type_OK13 = lhs8 / 37.47f;
+  int result_type_OK14 = lhs8 / (-37.47f);
+
+  long long lhs9 = 312345LL;
+
+  long long result_type_OK15 = lhs9 / 32;
+  long long result_type_OK16 = lhs9 / (-32);
+
+  int over_bits = 32 / 64;
+
+  return 0;
+}

--- a/llvm/test/compiler-course/Kholin_K_DivOpt/test_llvm_ir.ll
+++ b/llvm/test/compiler-course/Kholin_K_DivOpt/test_llvm_ir.ll
@@ -1,0 +1,166 @@
+; RUN: opt -load-pass-plugin %llvmshlibdir/DivOptPass_KholinKirill_FIIT3_LLVM_IR%pluginext -passes=div-opt-pass -S %s | FileCheck %s
+
+; CHECK: define dso_local noundef i32 @main() #0 {
+; CHECK-NEXT: entry:
+
+; CHECK: %1 = lshr i32 %0, 1
+; CHECK-NEXT: store i32 %1, ptr %result_type_OK1, align 4
+; CHECK: %div1 = udiv i32 %2, -2
+; CHECK-NEXT: store i32 %div1, ptr %UB1, align 4
+; CHECK: %4 = lshr i32 %3, 3
+; CHECK-NEXT: store i32 %4, ptr %result_type_OK2, align 4
+; CHECK: %6 = ashr i32 %5, 6
+; CHECK-NEXT: store i32 %6, ptr %result_type_OK3, align 4
+; CHECK: %div4 = sdiv i32 %7, -64
+; CHECK-NEXT: store i32 %div4, ptr %Not_UB1, align 4
+; CHECK: %9 = ashr i32 %sub, 6
+; CHECK-NEXT: store i32 %9, ptr %result_type_OK4, align 4
+; CHECK: %div7 = sdiv i32 %sub6, -64
+; CHECK-NEXT: store i32 %div7, ptr %Not_UB2, align 4
+; CHECK: %12 = lshr i32 %11, 5
+; CHECK-NEXT: store i32 %12, ptr %result_type_OK5, align 4
+; CHECK: %14 = lshr i32 %sub9, 5
+; CHECK-NEXT: store i32 %14, ptr %UB2, align 4
+; CHECK: %div11 = udiv i32 %15, 3
+; CHECK-NEXT: store i32 %div11, ptr %result_type_OK7, align 4
+; CHECK: %div13 = udiv i32 %sub12, 3
+; CHECK-NEXT: store i32 %div13, ptr %UB3, align 4
+; CHECK: %18 = ashr i32 %17, 2
+; CHECK-NEXT: store i32 %18, ptr %result_type_OK9, align 4
+; CHECK: %20 = ashr i32 %sub15, 2
+; CHECK-NEXT: store i32 %20, ptr %UB4, align 4
+; CHECK: %div17 = fdiv double %21, 4.000000e+00
+; CHECK-NEXT: store double %div17, ptr %result_type_OK11, align 8
+; CHECK: %div18 = fdiv double %22, -4.000000e+00
+; CHECK-NEXT: store double %div18, ptr %result_type_OK12, align 8
+; CHECK: %div19 = fdiv float %conv, 0x4042BC2900000000
+; CHECK: %div22 = fdiv float %conv21, 0xC042BC2900000000
+; CHECK: %26 = ashr i64 %25, 5
+; CHECK-NEXT: store i64 %26, ptr %result_type_OK15, align 8
+; CHECK: %div25 = sdiv i64 %27, -32
+; CHECK-NEXT: store i64 %div25, ptr %result_type_OK16, align 8
+; CHECK:  store i32 0, ptr %over_bits, align 4
+
+define dso_local noundef i32 @main() #0 {
+entry:
+  %retval = alloca i32, align 4
+  %lhs1 = alloca i32, align 4
+  %result_type_OK1 = alloca i32, align 4
+  %UB1 = alloca i32, align 4
+  %lhs2 = alloca i32, align 4
+  %result_type_OK2 = alloca i32, align 4
+  %lhs3 = alloca i32, align 4
+  %result_type_OK3 = alloca i32, align 4
+  %Not_UB1 = alloca i32, align 4
+  %result_type_OK4 = alloca i32, align 4
+  %Not_UB2 = alloca i32, align 4
+  %lhs4 = alloca i32, align 4
+  %result_type_OK5 = alloca i32, align 4
+  %UB2 = alloca i32, align 4
+  %lhs5 = alloca i32, align 4
+  %result_type_OK7 = alloca i32, align 4
+  %UB3 = alloca i32, align 4
+  %lhs6 = alloca i32, align 4
+  %result_type_OK9 = alloca i32, align 4
+  %UB4 = alloca i32, align 4
+  %lhs7 = alloca double, align 8
+  %result_type_OK11 = alloca double, align 8
+  %result_type_OK12 = alloca double, align 8
+  %lhs8 = alloca i32, align 4
+  %result_type_OK13 = alloca i32, align 4
+  %result_type_OK14 = alloca i32, align 4
+  %lhs9 = alloca i64, align 8
+  %result_type_OK15 = alloca i64, align 8
+  %result_type_OK16 = alloca i64, align 8
+  %over_bits = alloca i32, align 4
+  store i32 0, ptr %retval, align 4
+  store i32 1024, ptr %lhs1, align 4
+  %0 = load i32, ptr %lhs1, align 4
+  %div = udiv i32 %0, 2
+  store i32 %div, ptr %result_type_OK1, align 4
+  %1 = load i32, ptr %lhs1, align 4
+  %div1 = udiv i32 %1, -2
+  store i32 %div1, ptr %UB1, align 4
+  store i32 512, ptr %lhs2, align 4
+  %2 = load i32, ptr %lhs2, align 4
+  %div2 = udiv i32 %2, 8
+  store i32 %div2, ptr %result_type_OK2, align 4
+  store i32 256, ptr %lhs3, align 4
+  %3 = load i32, ptr %lhs3, align 4
+  %div3 = sdiv i32 %3, 64
+  store i32 %div3, ptr %result_type_OK3, align 4
+  %4 = load i32, ptr %lhs3, align 4
+  %div4 = sdiv i32 %4, -64
+  store i32 %div4, ptr %Not_UB1, align 4
+  %5 = load i32, ptr %lhs3, align 4
+  %sub = sub nsw i32 0, %5
+  %div5 = sdiv i32 %sub, 64
+  store i32 %div5, ptr %result_type_OK4, align 4
+  %6 = load i32, ptr %lhs3, align 4
+  %sub6 = sub nsw i32 0, %6
+  %div7 = sdiv i32 %sub6, -64
+  store i32 %div7, ptr %Not_UB2, align 4
+  store i32 128, ptr %lhs4, align 4
+  %7 = load i32, ptr %lhs4, align 4
+  %div8 = udiv i32 %7, 32
+  store i32 %div8, ptr %result_type_OK5, align 4
+  %8 = load i32, ptr %lhs4, align 4
+  %sub9 = sub nsw i32 0, %8
+  %div10 = udiv i32 %sub9, 32
+  store i32 %div10, ptr %UB2, align 4
+  store i32 128, ptr %lhs5, align 4
+  %9 = load i32, ptr %lhs5, align 4
+  %div11 = udiv i32 %9, 3
+  store i32 %div11, ptr %result_type_OK7, align 4
+  %10 = load i32, ptr %lhs5, align 4
+  %sub12 = sub nsw i32 0, %10
+  %div13 = udiv i32 %sub12, 3
+  store i32 %div13, ptr %UB3, align 4
+  store i32 126, ptr %lhs6, align 4
+  %11 = load i32, ptr %lhs6, align 4
+  %div14 = sdiv i32 %11, 4
+  store i32 %div14, ptr %result_type_OK9, align 4
+  %12 = load i32, ptr %lhs6, align 4
+  %sub15 = sub nsw i32 0, %12
+  %div16 = sdiv i32 %sub15, 4
+  store i32 %div16, ptr %UB4, align 4
+  store double 0x408BF770A3D70A3D, ptr %lhs7, align 8
+  %13 = load double, ptr %lhs7, align 8
+  %div17 = fdiv double %13, 4.000000e+00
+  store double %div17, ptr %result_type_OK11, align 8
+  %14 = load double, ptr %lhs7, align 8
+  %div18 = fdiv double %14, -4.000000e+00
+  store double %div18, ptr %result_type_OK12, align 8
+  store i32 6, ptr %lhs8, align 4
+  %15 = load i32, ptr %lhs8, align 4
+  %conv = sitofp i32 %15 to float
+  %div19 = fdiv float %conv, 0x4042BC2900000000
+  %conv20 = fptosi float %div19 to i32
+  store i32 %conv20, ptr %result_type_OK13, align 4
+  %16 = load i32, ptr %lhs8, align 4
+  %conv21 = sitofp i32 %16 to float
+  %div22 = fdiv float %conv21, 0xC042BC2900000000
+  %conv23 = fptosi float %div22 to i32
+  store i32 %conv23, ptr %result_type_OK14, align 4
+  store i64 312345, ptr %lhs9, align 8
+  %17 = load i64, ptr %lhs9, align 8
+  %div24 = sdiv i64 %17, 32
+  store i64 %div24, ptr %result_type_OK15, align 8
+  %18 = load i64, ptr %lhs9, align 8
+  %div25 = sdiv i64 %18, -32
+  store i64 %div25, ptr %result_type_OK16, align 8
+  store i32 0, ptr %over_bits, align 4
+  ret i32 0
+}
+
+attributes #0 = { mustprogress noinline norecurse nounwind optnone uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+
+!llvm.module.flags = !{!0, !1, !2, !3, !4}
+!llvm.ident = !{!5}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 8, !"PIC Level", i32 2}
+!2 = !{i32 7, !"PIE Level", i32 2}
+!3 = !{i32 7, !"uwtable", i32 2}
+!4 = !{i32 7, !"frame-pointer", i32 2}
+!5 = !{!"clang version 19.1.6 (git@github.com:Kirius257/compiler-course-2025.git 8797851e87b0c3c25247c18dd167cbbea02581cd)"}


### PR DESCRIPTION
### [**ПОСТАНОВКА ЗАДАЧИ**]
Написать transform LLVM Pass, который должен выполнять следующие оптимизации:
- Замена в некотором тестовом файле инструкций деления, где это возможно, 
   на инструкцию побитовый сдвиг вправо;

|_ОГРАНИЧЕНИЯ_|
Оптимизация применяется только в случае, если:

1.  Побитовый сдвиг вправо согласно стандарту языка C++ применяется только к
     двум целочисленным операндам;
2. Правый операнд, отвечающий за кол-во бит сдвига, неотрицательный;
3. Количество бит, на которое выполняется сдвиг, не превышает число бит в двоичной записи левого опера[нда;

### [**ОПИСАНИЕ РЕШЕНИЯ**]

**СРЕДСТВА, ОПРЕДЕЛЯЮЩИЕ ИНТЕРФЕЙС PASS**

_Выбор подкласса PASS:_ FunctionPass Class Reference;
_Уровень оптимизации:_ BasicBlock Class Reference;
_Инструменты:_ IRBuilder;
_Структура данных для замены инструкций:_ vector;

**АЛГОРИТМ ОБХОДА**

1. Создать два цикла: по базовым блокам функций и инструкциям этих блоков;
2. В каждом блоке найти все инструкции деления, для которых возможна замена
    на инструкцию побитовый сдвиг вправо и соблюдаются все ограничения;
3. Найденную инструкцию добавить в вектор для замены инструкций деления;
4. Выполнить замену инструкции деления на побитовый сдвиг с помощью
    конструктора IRBuilder. 

**РЕЗУЛЬТАТ**
Optimized IR

### СПИСОК ИСПРАВЛЕНИЙ

- Удалены артефакты в тестовом файле с расширением .cpp
